### PR TITLE
Add job detail and unclaim endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ The FastAPI backend currently provides a few in-memory job management endpoints.
 | GET   | `/jobs/`        | List all jobs                   |
 | POST  | `/jobs/`        | Create a job `{part_number}`    |
 | POST  | `/jobs/claim`   | Claim job `{job_id, username}`  |
+| POST  | `/jobs/unclaim` | Unclaim job `{job_id}`          |
 | POST  | `/jobs/complete`| Complete job `{job_id}`         |
+| GET   | `/jobs/{job_id}`| Retrieve a job by ID            |
 | POST  | `/users/`       | Create a user `{username, password}` |
 | GET   | `/users/`       | List all users                     |
 | GET   | `/users/{username}` | Retrieve a user by username |


### PR DESCRIPTION
## Summary
- allow retrieving a job by id
- support unclaiming a job
- document the new endpoints
- test the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685893737d5083239524a537edcec7d0