### PR TITLE
Add user jobs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,4 +187,5 @@ The FastAPI backend currently provides a few in-memory job management endpoints.
 | POST  | `/users/`       | Create a user `{username, password}` |
 | GET   | `/users/`       | List all users                     |
 | GET   | `/users/{username}` | Retrieve a user by username |
+| GET   | `/users/{username}/jobs` | List jobs assigned to user |
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,14 @@ def get_user(username: str):
         raise HTTPException(status_code=404, detail="user not found")
     return user
 
+
+@app.get("/users/{username}/jobs")
+def get_user_jobs(username: str):
+    user = _find_user(username)
+    if not user:
+        raise HTTPException(status_code=404, detail="user not found")
+    return [j for j in _jobs if j.get("operator_id") == user["id"]]
+
 @app.get("/jobs/")
 def read_jobs():
     return _jobs

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -84,3 +84,17 @@ def test_unclaim_and_job_detail():
     detail = client.get(f"/jobs/{jid}").json()
     events = [h["event"] for h in detail["history"]]
     assert "unclaimed" in events
+
+
+def test_user_jobs_endpoint():
+    client.post("/users/", json={"username": "erin"})
+    job = client.post("/jobs/", json={"part_number": "999"}).json()
+    jid = job["id"]
+    client.post("/jobs/claim", json={"job_id": jid, "username": "erin"})
+
+    jobs = client.get("/users/erin/jobs").json()
+    assert any(j["id"] == jid for j in jobs)
+
+    client.post("/jobs/complete", json={"job_id": jid})
+    jobs = client.get("/users/erin/jobs").json()
+    assert any(j["id"] == jid and j["status"] == "finished" for j in jobs)


### PR DESCRIPTION
## Summary
- add endpoint for listing jobs assigned to a given user
- document new endpoint in README
- test the new `/users/{username}/jobs` API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685895a66e308323b3a36702cf3e08b9