### PR TITLE
Add basic web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,21 @@ The FastAPI backend currently provides a few in-memory job management endpoints.
 | GET   | `/users/{username}` | Retrieve a user by username |
 | GET   | `/users/{username}/jobs` | List jobs assigned to user |
 
+
+## 🖥️ Basic Web UI
+A minimal HTML interface is provided under `frontend/`. It communicates with the
+existing API and can be served locally.
+
+### Run the backend
+```bash
+cd backend/app
+python main.py
+```
+This starts the API at `http://localhost:8000`.
+
+### Serve the UI
+From the project root run:
+```bash
+python -m http.server 8080 -d frontend
+```
+Then open `http://localhost:8080` in your browser.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 sqlalchemy
 passlib[bcrypt]
+uvicorn

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,23 @@
+# Frontend UI
+
+This directory contains a very small HTML page used to interact with the
+FastAPI backend. It relies only on browser JavaScript and can be served
+with Python's built-in HTTP server.
+
+## Usage
+
+1. Make sure the backend API is running:
+   ```bash
+   cd backend/app
+   python main.py  # or `uvicorn app.main:app` if uvicorn is installed
+   ```
+   The API will be available at `http://localhost:8000`.
+
+2. Serve this UI (from the repository root):
+   ```bash
+   python -m http.server 8080 -d frontend
+   ```
+   Then open your browser to [http://localhost:8080](http://localhost:8080).
+
+The UI allows you to create jobs and claim/complete them using the existing
+API endpoints.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Hybrid Production Scheduler</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; }
+        .job { padding: 4px; margin-bottom: 4px; border-bottom: 1px solid #ccc; }
+        button { margin-left: 4px; }
+    </style>
+</head>
+<body>
+<h1>Job Board</h1>
+<div id="jobs">Loading...</div>
+
+<h2>Create Job</h2>
+<form id="jobForm">
+    <label>Part Number: <input id="part" required></label>
+    <button type="submit">Create</button>
+</form>
+
+<script>
+const API = 'http://localhost:8000';
+async function loadJobs() {
+    const res = await fetch(`${API}/jobs/`);
+    const jobs = await res.json();
+    const container = document.getElementById('jobs');
+    container.innerHTML = '';
+    jobs.forEach(j => {
+        const div = document.createElement('div');
+        div.className = 'job';
+        div.innerHTML = `<strong>${j.part_number || ''}</strong> - ${j.status}`;
+        const claimBtn = document.createElement('button');
+        claimBtn.textContent = 'Claim';
+        claimBtn.onclick = async () => {
+            const user = prompt('Username');
+            if(!user) return;
+            await fetch(`${API}/jobs/claim`, {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({job_id: j.id, username: user})
+            });
+            loadJobs();
+        };
+        const completeBtn = document.createElement('button');
+        completeBtn.textContent = 'Complete';
+        completeBtn.onclick = async () => {
+            await fetch(`${API}/jobs/complete`, {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({job_id: j.id})
+            });
+            loadJobs();
+        };
+        div.appendChild(claimBtn);
+        div.appendChild(completeBtn);
+        container.appendChild(div);
+    });
+}
+
+document.getElementById('jobForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const part = document.getElementById('part').value;
+    await fetch(`${API}/jobs/`, {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({part_number: part})
+    });
+    document.getElementById('part').value = '';
+    loadJobs();
+});
+
+loadJobs();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal HTML frontend under `frontend/`
- document how to run backend and serve the UI
- include `uvicorn` in backend requirements for running the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685897bef52083238fe53c25347af2ad