### PR TITLE
Add job archive and status update UI

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -108,3 +108,19 @@ def test_delete_job():
     assert response.json()["id"] == jid
     response = client.get(f"/jobs/{jid}")
     assert response.status_code == 404
+
+
+def test_archive_and_history():
+    job = client.post("/jobs/", json={"part_number": "ARC"}).json()
+    jid = job["id"]
+    client.post("/jobs/complete", json={"job_id": jid})
+
+    arch = client.post("/jobs/archive", json={"job_id": jid})
+    assert arch.status_code == 200
+    assert arch.json()["id"] == jid
+
+    jobs = client.get("/jobs/").json()
+    assert all(j["id"] != jid for j in jobs)
+
+    history = client.get("/jobs/history").json()
+    assert any(j["id"] == jid for j in history)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,5 +19,8 @@ with Python's built-in HTTP server.
    ```
    Then open your browser to [http://localhost:8080](http://localhost:8080).
 
-The UI allows you to create jobs and claim/complete them using the existing
-API endpoints.
+The UI allows you to create jobs, update their status, delete them, and
+archive finished jobs to a simple history page.
+
+Open `index.html` for the active job board or `history.html` to view the
+archive.

--- a/frontend/history.html
+++ b/frontend/history.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Completed Jobs</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; }
+        .job { padding: 4px; margin-bottom: 4px; border-bottom: 1px solid #ccc; }
+    </style>
+</head>
+<body>
+<h1>Completed Jobs</h1>
+<p><a href="index.html">Back to Job Board</a></p>
+<div id="history">Loading...</div>
+
+<script>
+const API = 'http://localhost:8000';
+async function loadHistory() {
+    const res = await fetch(`${API}/jobs/history`);
+    const jobs = await res.json();
+    const container = document.getElementById('history');
+    container.innerHTML = '';
+    jobs.forEach(j => {
+        const div = document.createElement('div');
+        div.className = 'job';
+        div.textContent = `${j.part_number || ''} - ${j.status}`;
+        container.appendChild(div);
+    });
+}
+loadHistory();
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 <h1>Job Board</h1>
+<p><a href="history.html">View Completed Jobs</a></p>
 <div id="jobs">Loading...</div>
 
 <h2>Create Job</h2>
@@ -30,30 +31,55 @@ async function loadJobs() {
         const div = document.createElement('div');
         div.className = 'job';
         div.innerHTML = `<strong>${j.part_number || ''}</strong> - ${j.status}`;
-        const claimBtn = document.createElement('button');
-        claimBtn.textContent = 'Claim';
-        claimBtn.onclick = async () => {
-            const user = prompt('Username');
-            if(!user) return;
-            await fetch(`${API}/jobs/claim`, {
-                method: 'POST',
-                headers: {'Content-Type':'application/json'},
-                body: JSON.stringify({job_id: j.id, username: user})
-            });
+
+        if (j.status === 'unclaimed') {
+            const startBtn = document.createElement('button');
+            startBtn.textContent = 'Start';
+            startBtn.onclick = async () => {
+                const user = prompt('Username');
+                if(!user) return;
+                await fetch(`${API}/jobs/claim`, {
+                    method: 'POST',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify({job_id: j.id, username: user})
+                });
+                loadJobs();
+            };
+            div.appendChild(startBtn);
+        } else if (j.status === 'running') {
+            const finishBtn = document.createElement('button');
+            finishBtn.textContent = 'Finish';
+            finishBtn.onclick = async () => {
+                await fetch(`${API}/jobs/complete`, {
+                    method: 'POST',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify({job_id: j.id})
+                });
+                loadJobs();
+            };
+            div.appendChild(finishBtn);
+        } else if (j.status === 'finished') {
+            const archiveBtn = document.createElement('button');
+            archiveBtn.textContent = 'Archive';
+            archiveBtn.onclick = async () => {
+                await fetch(`${API}/jobs/archive`, {
+                    method: 'POST',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify({job_id: j.id})
+                });
+                loadJobs();
+            };
+            div.appendChild(archiveBtn);
+        }
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.textContent = 'Delete';
+        deleteBtn.onclick = async () => {
+            await fetch(`${API}/jobs/${j.id}`, { method: 'DELETE' });
             loadJobs();
         };
-        const completeBtn = document.createElement('button');
-        completeBtn.textContent = 'Complete';
-        completeBtn.onclick = async () => {
-            await fetch(`${API}/jobs/complete`, {
-                method: 'POST',
-                headers: {'Content-Type':'application/json'},
-                body: JSON.stringify({job_id: j.id})
-            });
-            loadJobs();
-        };
-        div.appendChild(claimBtn);
-        div.appendChild(completeBtn);
+        div.appendChild(deleteBtn);
+
         container.appendChild(div);
     });
 }


### PR DESCRIPTION
## Summary
- allow archiving of finished jobs in API
- expose `GET /jobs/history` and `POST /jobs/archive`
- enhance UI to start, finish, delete and archive jobs
- add `history.html` page to view archived jobs
- document UI changes
- test new archive functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6858b7b6d89483238d9d718b8d57ab5b